### PR TITLE
Fix DB private IP name so that it is unique

### DIFF
--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "google_compute_global_address" "private_ip_address" {
-  name = "private-ip-address"
+  name = "private-ip-address-${var.deployment_id}"
   purpose = "VPC_PEERING"
   address = "172.16.4.0"
   address_type = "INTERNAL"


### PR DESCRIPTION
For issue https://issues.redhat.com/browse/AAP-19684

This PR fixes a DB bug where the private IP address is hardcoded and only one deployment could be done.  This PR makes the name of the private IP unique so multiple deployments can be done.

To test:

checkout PR
terraform init
terraform apply -var deployment_id=mydeploy -var infrastructure_db_username=dbadmin -var infrastructure_db_password=ChangeMe1234 -var infrastructure_controller_count=2 -var infrastructure_execution_count=1 -var infrastructure_eda_count=1 -var region=us-central1 -var zone=us-central1-a
